### PR TITLE
pass contrasts directly to model.matrix

### DIFF
--- a/man/kknn.Rd
+++ b/man/kknn.Rd
@@ -15,7 +15,7 @@ In addition even ordinal and continuous variables can be predicted.
 \usage{
 kknn(formula = formula(train), train, test, na.action = na.omit(), 
 	k = 7, distance = 2, kernel = "optimal", ykernel = NULL, scale=TRUE,
-	contrasts = c('unordered' = "contr.dummy", ordered = "contr.ordinal"))
+	contrasts = c(unordered = kknn::contr.dummy, ordered = kknn::contr.ordinal))
 kknn.dist(learn, valid, k = 10, distance = 2)     
 }
 \arguments{

--- a/man/train.kknn.Rd
+++ b/man/train.kknn.Rd
@@ -11,8 +11,8 @@
 }
 \usage{
 train.kknn(formula, data, kmax = 11, ks = NULL, distance = 2, kernel = "optimal",
-	ykernel = NULL, scale = TRUE, contrasts = c('unordered' = "contr.dummy",
-	ordered = "contr.ordinal"), ...)
+	ykernel = NULL, scale = TRUE, contrasts = c(unordered = kknn::contr.dummy,
+	ordered = kknn::contr.ordinal), ...)
 cv.kknn(formula, data, kcv = 10, ...)
 }
 \arguments{


### PR DESCRIPTION
Fixes #16 

Rather than using `options` to set the contrasts, this sets them directly on `model.matrix` via the argument `contrasts.arg`.

Feedback/ comments are welcome!