### PR TITLE
remove outcome from contrast list

### DIFF
--- a/R/kknn.R
+++ b/R/kknn.R
@@ -91,7 +91,8 @@ contr.int <- function (n, contrasts = TRUE)
 
 
 get_contrasts <- function(mt, contrasts){
-  dataClasses <- attr(mt, "dataClasses")
+  yLocation <- attr(mt, "response")
+  dataClasses <- attr(mt, "dataClasses")[-yLocation]
   unorderedVariables <- names(dataClasses[dataClasses %in% c("factor", "character")])
   orderedVariables   <- names(dataClasses[dataClasses %in% c("ordered")])
   if (length(unorderedVariables) == 0 && length(orderedVariables) == 0) {


### PR DESCRIPTION
With R 4.5.0, we see extra warnings (shown below). R has more rigorous checking code for contrasts, and the issue is in `get_contrasts()`.  That function includes the outcome column in the contrast argument and, when predicting, there is now an error that the column is absent.

This patch is pretty simple and fixes that. 

If this works for you, could you do another submission? I know that you just did one, but our tests are failing from the additional warnings (and users might be confused by the new messages). 

Before: 

``` r
library(kknn)

data(ionosphere)
ionosphere.learn <- ionosphere[1:200, ]
ionosphere.valid <- ionosphere[-c(1:200), ]
fit.kknn <- train.kknn(class ~ ., data = ionosphere.learn)

predict(fit.kknn, ionosphere.valid[1:3,], type = "prob")
#> Warning in model.matrix.default(mt2, test, contrasts.arg = contrasts.arg):
#> variable 'class' is absent, its contrast will be ignored
#>      b g
#> [1,] 0 1
#> [2,] 0 1
#> [3,] 1 0
```

<sup>Created on 2025-04-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

After:

``` r
library(kknn)

data(ionosphere)
ionosphere.learn <- ionosphere[1:200, ]
ionosphere.valid <- ionosphere[-c(1:200), ]
fit.kknn <- train.kknn(class ~ ., data = ionosphere.learn)

predict(fit.kknn, ionosphere.valid[1:3,], type = "prob")
#>      b g
#> [1,] 0 1
#> [2,] 0 1
#> [3,] 1 0
```

<sup>Created on 2025-04-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>