### PR TITLE
Fix valgrind error from CRAN

### DIFF
--- a/src/dm.c
+++ b/src/dm.c
@@ -39,8 +39,8 @@ void dm(double *learn, double *valid, int *n, int *m, int *p, double *dm, int *c
     kk = MIN(kk, *n);
     nn = MIN(2L*kk, *n);
 
-    cvec = (int *) R_alloc(nn, sizeof(int));
-    dvec = (double *) R_alloc(nn, sizeof(double));
+    cvec = (int *) R_alloc(nn+1L, sizeof(int));
+    dvec = (double *) R_alloc(nn+1L, sizeof(double));
 //    for(t=0;t<nn;t++) dvec[t]= BIG;
 
     for(j=0;j<(*m);j++){


### PR DESCRIPTION
Fix the valgrind error from CRAN in https://www.stats.ox.ac.uk/pub/bdr/memtests/valgrind/kknn/kknn-Ex.Rout

See https://github.com/koenderks/kknn/actions/runs/15094722154 for pre-fix check output.

See https://github.com/koenderks/kknn/actions/runs/15094760748/job/42427983986 for post-fix check output.